### PR TITLE
Fix gh-7: Avoid leak from cell delegate strong reference.

### DIFF
--- a/CFAlertViewController/Cells/CFAlertActionTableViewCell.swift
+++ b/CFAlertViewController/Cells/CFAlertActionTableViewCell.swift
@@ -44,7 +44,7 @@ public class CFAlertActionTableViewCell: UITableViewCell {
     public static func identifier() -> String    {
         return String(describing: CFAlertActionTableViewCell.self)
     }
-    public var delegate: CFAlertActionTableViewCellDelegate?
+    public weak var delegate: CFAlertActionTableViewCellDelegate?
     public var actionButtonTopMargin: CGFloat = 0.0 {
         didSet {
             // Update Constraint


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/Codigami/CFAlertViewController/blob/develop/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CFAlertViewController/)
* [x] I have searched for a similar pull request in the [project](https://github.com/Codigami/CFAlertViewController/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: 
- 7

### Pull Request Description
The issue mentions a leak produced by simply using the class. A strong reference from the Alert cell was at least one place where the alert class was held.

![screen shot 2017-08-25 at 5 02 48 pm](https://user-images.githubusercontent.com/2918150/29703051-50084312-89b7-11e7-9a1e-698f82f1d390.png)


